### PR TITLE
 add endpoint to fetch incompleted ToDo items by user ID

### DIFF
--- a/src/ToDoList.Api/Endpoints/AdminEndpoints.cs
+++ b/src/ToDoList.Api/Endpoints/AdminEndpoints.cs
@@ -66,5 +66,22 @@ public static class AdminEndpoints
         .WithName("GetCompletedToDos")
         .WithTags("ToDoItems");
 
+        app.MapGet("/todo/incompleted", async (
+         [FromServices] IToDoItemRepository repository,
+         HttpContext httpContext) =>
+        {
+            if (!httpContext.User.Identity.IsAuthenticated)
+                return Results.Unauthorized();
+
+            var userIdClaim = httpContext.User.Claims.FirstOrDefault(c => c.Type == ClaimTypes.NameIdentifier);
+            if (userIdClaim is null || !long.TryParse(userIdClaim.Value, out var userId))
+                return Results.BadRequest("Invalid user ID");
+
+            var items = await repository.SelectIncompletedAsync();
+            return Results.Ok(items);
+        })
+        .WithName("GetIncompletedToDos")
+        .WithTags("ToDoItems");
+
     }
 }

--- a/src/ToDoList.Infrastructure/Persistence/Repositories/ToDoItemRepository.cs
+++ b/src/ToDoList.Infrastructure/Persistence/Repositories/ToDoItemRepository.cs
@@ -57,10 +57,13 @@ public class ToDoItemRepository : IToDoItemRepository
     }
 
 
-    public Task<ICollection<ToDoItem>> SelectIncompletedAsync()
+    public async Task<ICollection<ToDoItem>> SelectIncompletedAsync()
     {
-        throw new NotImplementedException();
+        return await _context.ToDoItems
+            .Where(x => !x.IsCompleted)
+            .ToListAsync();
     }
+
 
     public Task<ICollection<ToDoItem>> SelectOverdueItemsAsync()
     {


### PR DESCRIPTION
Adds support for retrieving all not yet completed ToDo items by the currently authenticated user.

Endpoint: /todo/incompleted

Secured with JWT and user filtering